### PR TITLE
delivery: http1 chunked encoding trailers support & other improvements

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -731,7 +731,8 @@ uint16_t HTTP1_DissectRequest(struct http_conn *, struct http *);
 uint16_t HTTP1_DissectResponse(struct http_conn *, struct http *resp,
     const struct http *req);
 unsigned HTTP1_Write(const struct worker *, const struct http *, const int *);
-void HTTP1_MarkTrailer(struct http *hp);
+int HTTP1_InTrailer(const struct http *hp, const char *hdr);
+void HTTP1_PrepTrailer(struct http *hp);
 unsigned HTTP1_WriteChunkedTrailer(const struct worker *, const struct http *);
 
 #define HTTPH_R_PASS	(1 << 0)	/* Request (c->b) in pass mode */

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -690,6 +690,7 @@ void http_PrintfHeader(struct http *to, const char *fmt, ...)
 void http_TimeHeader(struct http *to, const char *fmt, double now);
 void http_Proto(struct http *to);
 void http_SetHeader(struct http *to, const char *hdr);
+void _http_SetTrailer(struct http *to, const char *hdr);
 void http_SetH(struct http *to, unsigned n, const char *fm);
 void http_ForceField(struct http *to, unsigned n, const char *t);
 void HTTP_Setup(struct http *, struct ws *, struct vsl_log *, enum VSL_tag_e);

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -730,6 +730,7 @@ uint16_t HTTP1_DissectRequest(struct http_conn *, struct http *);
 uint16_t HTTP1_DissectResponse(struct http_conn *, struct http *resp,
     const struct http *req);
 unsigned HTTP1_Write(const struct worker *, const struct http *, const int *);
+void HTTP1_MarkTrailer(struct http *hp);
 unsigned HTTP1_WriteChunkedTrailer(const struct worker *, const struct http *);
 
 #define HTTPH_R_PASS	(1 << 0)	/* Request (c->b) in pass mode */

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -729,7 +729,8 @@ uint16_t HTTP1_DissectHdrs(struct http *, char **, const char *, const unsigned)
 uint16_t HTTP1_DissectRequest(struct http_conn *, struct http *);
 uint16_t HTTP1_DissectResponse(struct http_conn *, struct http *resp,
     const struct http *req);
-unsigned HTTP1_Write(const struct worker *w, const struct http *hp, const int*);
+unsigned HTTP1_Write(const struct worker *, const struct http *, const int *);
+unsigned HTTP1_WriteChunkedTrailer(const struct worker *, const struct http *);
 
 #define HTTPH_R_PASS	(1 << 0)	/* Request (c->b) in pass mode */
 #define HTTPH_R_FETCH	(1 << 1)	/* Request (c->b) for fetch */

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -1286,8 +1286,13 @@ http_TimeHeader(struct http *to, const char *fmt, double now)
 }
 
 /*--------------------------------------------------------------------
- * XXX trailers: We cannot unset what we've already sent, but do we really
- * want to prevent sending headers twice?
+ *
+ * Trailers note: HTTP1_PrepTrailer has moved all headers announced in Trailer:
+ * to before thd, so if we get an Unset for a trailer-part, it should only
+ * affect another trailer-part.  Yet if an unset header was not announced as a
+ * Trailer, we unset something which we've already sent and send the new value
+ * again as a trailer.  If we wanted to avoid this, we would need to check any
+ * trailer-part for being announced.
  */
 
 void

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -250,6 +250,7 @@ http_PutField(struct http *to, int field, const char *string)
 	char *p;
 
 	CHECK_OBJ_NOTNULL(to, HTTP_MAGIC);
+	AZ(to->thd);
 	p = WS_Copy(to->ws, string, -1);
 	if (p == NULL) {
 		http_fail(to);
@@ -348,6 +349,7 @@ http_CollectHdrSep(struct http *hp, const char *hdr, const char *sep)
 	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
 	if (WS_Overflowed(hp->ws))
 		return;
+	XXXAZ(hp->thd);
 
 	if (sep == NULL || *sep == '\0')
 		sep = ", ";
@@ -708,6 +710,7 @@ http_DoConnection(struct http *hp)
 	else
 		retval = SC_NULL;
 
+	AZ(hp->thd);
 	http_CollectHdr(hp, H_Connection);
 	if (!http_GetHdr(hp, H_Connection, &h))
 		return (retval);
@@ -781,6 +784,7 @@ http_SetStatus(struct http *to, uint16_t status)
 	const char *sstr = NULL;
 
 	CHECK_OBJ_NOTNULL(to, HTTP_MAGIC);
+	AZ(to->thd);
 	/*
 	 * We allow people to use top digits for internal VCL
 	 * signalling, but strip them from the ASCII version.
@@ -820,6 +824,7 @@ http_ForceField(struct http *to, unsigned n, const char *t)
 	int i;
 
 	CHECK_OBJ_NOTNULL(to, HTTP_MAGIC);
+	AZ(to->thd);
 	assert(n < HTTP_HDR_FIRST);
 	AN(t);
 	if (to->hd[n].b == NULL || strcmp(to->hd[n].b, t)) {
@@ -839,6 +844,7 @@ http_PutResponse(struct http *to, const char *proto, uint16_t status,
 {
 
 	CHECK_OBJ_NOTNULL(to, HTTP_MAGIC);
+	AZ(to->thd);
 	if (proto != NULL)
 		http_SetH(to, HTTP_HDR_PROTO, proto);
 	http_SetStatus(to, status);
@@ -930,6 +936,7 @@ HTTP_Decode(struct http *to, const uint8_t *fm)
 {
 
 	CHECK_OBJ_NOTNULL(to, HTTP_MAGIC);
+	AZ(to->thd);
 	AN(to->vsl);
 	if (fm == 0) {
 		VSLb(to->vsl, SLT_Error, "No headers in object");
@@ -1064,6 +1071,7 @@ HTTP_Merge(struct worker *wrk, struct objcore *oc, struct http *to)
 
 	ptr = ObjGetAttr(wrk, oc, OA_HEADERS, NULL);
 	AN(ptr);
+	AZ(to->thd);
 
 	to->status = vbe16dec(ptr + 2);
 	ptr += 4;
@@ -1094,6 +1102,7 @@ http_filterfields(struct http *to, const struct http *fm, unsigned how)
 
 	CHECK_OBJ_NOTNULL(fm, HTTP_MAGIC);
 	CHECK_OBJ_NOTNULL(to, HTTP_MAGIC);
+	AZ(to->thd);
 	to->nhd = HTTP_HDR_FIRST;
 	to->status = fm->status;
 	for (u = HTTP_HDR_FIRST; u < fm->nhd; u++) {
@@ -1248,17 +1257,22 @@ http_TimeHeader(struct http *to, const char *fmt, double now)
 	to->nhd++;
 }
 
-/*--------------------------------------------------------------------*/
+/*--------------------------------------------------------------------
+ * XXX trailers: We cannot unset what we've already sent, but do we really
+ * want to prevent sending headers twice?
+ */
 
 void
 http_Unset(struct http *hp, const char *hdr)
 {
-	uint16_t u, v;
+	uint16_t u, v, d = 0;
 
 	for (v = u = HTTP_HDR_FIRST; u < hp->nhd; u++) {
 		Tcheck(hp->hd[u]);
 		if (http_IsHdr(&hp->hd[u], hdr)) {
 			http_VSLH_del(hp, u);
+			if (u < hp->thd)
+				d++;
 			continue;
 		}
 		if (v != u) {
@@ -1267,7 +1281,18 @@ http_Unset(struct http *hp, const char *hdr)
 		}
 		v++;
 	}
+	if (hp->nhd == v)
+		return;
+
+	assert(hp->nhd > v);
 	hp->nhd = v;
+
+	if (d > 0) {
+		assert(hp->thd > 0);
+		hp->thd -= d;
+		assert(hp->thd > 0);
+		assert(hp->thd <= v);
+	}
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -1111,6 +1111,7 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 		ctx.vcl = req->vcl;
 		ctx.http_req = req->http;
 		ctx.http_req_top = req->top->http;
+		ctx.http_resp_top = req->top->resp;
 		ctx.http_resp = req->resp;
 		ctx.req = req;
 		ctx.sp = req->sp;

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -45,6 +45,11 @@
 const void * const vrt_magic_string_end = &vrt_magic_string_end;
 const void * const vrt_magic_string_unset = &vrt_magic_string_unset;
 
+#define VRTHDRWHERE(n, s) [HDR_ ## n] = #s,
+const char *hdrwhere[] = {
+#include "tbl/vrt_hdr_where.h"
+};
+
 /*--------------------------------------------------------------------*/
 
 void
@@ -104,14 +109,21 @@ VRT_hit_for_pass(VRT_CTX, VCL_DURATION d)
 	    oc->ttl, oc->grace, oc->keep, oc->t_origin);
 }
 
-/*--------------------------------------------------------------------*/
+static inline void
+hdrexplain(const char **why, const char *reason)
+{
+	if (why)
+		*why = reason;
+}
 
-struct http *
-VRT_selecthttp(VRT_CTX, enum gethdr_e where)
+static struct http *
+ctx_selecthttp(VRT_CTX, enum gethdr_e where, const char **why)
 {
 	struct http *hp;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	hdrexplain(why, "(unknown)");
+
 	switch (where) {
 	case HDR_REQ:
 		hp = ctx->http_req;
@@ -119,19 +131,131 @@ VRT_selecthttp(VRT_CTX, enum gethdr_e where)
 	case HDR_REQ_TOP:
 		hp = ctx->http_req_top;
 		break;
+	case HDR_RESP:
+		hp = ctx->http_resp;
+		break;
+	case HDR_RESP_TOP:
+		hp = ctx->http_resp_top;
+
+		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+		if (ctx->req->esi_level > 0 ||
+		    ctx->method & (VCL_MET_DELIVER|VCL_MET_SYNTH))
+			break;
+
+		hdrexplain(why, "at esi level 0 outside vcl_deliver/"
+			   "vcl_synth");
+		return (NULL);
+	case HDR_OBJ:
+		/* explain and return NULL instead? */
+		WRONG("obj.http access only through VRT_GetHdr()");
 	case HDR_BEREQ:
 		hp = ctx->http_bereq;
 		break;
 	case HDR_BERESP:
 		hp = ctx->http_beresp;
 		break;
-	case HDR_RESP:
-		hp = ctx->http_resp;
-		break;
 	default:
-		WRONG("VRT_selecthttp 'where' invalid");
+		WRONG("ctx_selecthttp 'where' invalid");
 	}
 	return (hp);
+}
+
+/*--------------------------------------------------------------------
+ * check if writing to this header is ok in addition to the compile-time
+ * checks from vcc.
+ *
+ * this is a place for potential future top req/resp locking needs also
+ *
+ * returns NULL if access fails and returns reason in why if why != NULL
+ */
+
+struct http *
+VRT_http_ref_rw(VRT_CTX, enum gethdr_e where, const char **why)
+{
+	struct http *hp;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	hp = ctx_selecthttp(ctx, where, why);
+	if (hp == NULL)
+		return (hp);
+
+	switch (where) {
+	case HDR_REQ_TOP:
+		/*
+		 * HDR_REQ_TOP write not allowed by vcc, should be possible
+		 * now (e.g. for cheesy communication between esi subrequests)
+		 */
+		return (NULL);
+#ifdef XXX_CONSIDER_THIS
+	case HDR_RESP:
+		/*
+		 * writing to resp.http.* from esi_level > 0 has no effect (as
+		 * headers are discarded), so we should actually fail write
+		 * access for POLA
+		 */
+		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+		if (ctx->req->esi_level == 0)
+			break;
+		hdrexplain(why, "at esi level > 0");
+		return (NULL);
+#endif
+	case HDR_RESP_TOP:
+		if (hp->thd > 0)
+			break;
+		hdrexplain(why, "unless sending Trailers");
+		return (NULL);
+	default:
+		break;
+	}
+	return (hp);
+}
+
+/*--------------------------------------------------------------------
+ * read only access
+ *
+ * returns NULL if access fails and returns reason in why if why != NULL
+ */
+
+const struct http *
+VRT_http_ref_ro(VRT_CTX, enum gethdr_e where, const char **why)
+{
+	return (ctx_selecthttp(ctx, where, why));
+}
+
+/*--------------------------------------------------------------------
+ * release access
+ */
+void
+VRT_http_deref_rw(struct http **hp)
+{
+	/* noop for now */
+	*hp = NULL;
+}
+void
+VRT_http_deref_ro(const struct http **hp)
+{
+	/* noop for now */
+	*hp = NULL;
+}
+
+/*--------------------------------------------------------------------*/
+
+const char *
+VRT_hdr_where(const enum gethdr_e where)
+{
+	return (hdrwhere[where]);
+}
+
+/*--------------------------------------------------------------------*/
+void
+VRT_hdr_fail(VRT_CTX, const struct gethdr_s * const hs,
+    const char *err, const char *why)
+{
+	return (VRT_fail(ctx, "%s%.*s %s %s",
+			 VRT_hdr_where(hs->where),
+			 (int)*hs->what - 1, hs->what + 1,
+			 err, why));
 }
 
 /*--------------------------------------------------------------------*/
@@ -140,7 +264,8 @@ const char *
 VRT_GetHdr(VRT_CTX, const struct gethdr_s *hs)
 {
 	const char *p;
-	struct http *hp;
+	const struct http *hp;
+	const char *why;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (hs->where == HDR_OBJ) {
@@ -149,10 +274,15 @@ VRT_GetHdr(VRT_CTX, const struct gethdr_s *hs)
 		return(HTTP_GetHdrPack(ctx->req->wrk, ctx->req->objcore,
 		    hs->what));
 	}
-	hp = VRT_selecthttp(ctx, hs->where);
+	hp = VRT_http_ref_ro(ctx, hs->where, &why);
+	if (hp == NULL) {
+		VRT_hdr_fail(ctx, hs, "not accessible", why);
+		return (NULL);
+	}
 	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
 	if (!http_GetHdr(hp, hs->what, &p))
-		return (NULL);
+		p = NULL;
+	VRT_http_deref_ro(&hp);
 	return (p);
 }
 
@@ -247,11 +377,16 @@ VRT_SetHdr(VRT_CTX , const struct gethdr_s *hs,
 	struct http *hp;
 	va_list ap;
 	const char *b;
+	const char *why;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	AN(hs);
 	AN(hs->what);
-	hp = VRT_selecthttp(ctx, hs->where);
+	hp = VRT_http_ref_rw(ctx, hs->where, &why);
+	if (hp == NULL) {
+		VRT_hdr_fail(ctx, hs, "not writable", why);
+		return;
+	}
 	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
 	va_start(ap, p);
 	if (p == vrt_magic_string_unset) {
@@ -259,13 +394,16 @@ VRT_SetHdr(VRT_CTX , const struct gethdr_s *hs,
 	} else {
 		b = VRT_String(hp->ws, hs->what + 1, p, ap);
 		if (b == NULL) {
-			VSLb(ctx->vsl, SLT_LostHeader, "%s", hs->what + 1);
+			VSLb(ctx->vsl, SLT_LostHeader, "%s%.*s",
+			     VRT_hdr_where(hs->where), (int)*hs->what - 1,
+			     hs->what + 1);
 		} else {
 			http_Unset(hp, hs->what);
 			http_SetHeader(hp, b);
 		}
 	}
 	va_end(ap);
+	VRT_http_deref_rw(&hp);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -130,6 +130,10 @@ VRT_HDR_LR(resp,   reason,	HTTP_HDR_REASON)
 VRT_STATUS_L(resp)
 VRT_STATUS_R(resp)
 
+VRT_HDR_R(resp_top,   proto,	HTTP_HDR_PROTO)
+VRT_HDR_R(resp_top,   reason,	HTTP_HDR_REASON)
+VRT_STATUS_R(resp_top)
+
 VRT_HDR_LR(bereq,  method,	HTTP_HDR_METHOD)
 VRT_HDR_LR(bereq,  url,		HTTP_HDR_URL)
 VRT_HDR_LR(bereq,  proto,	HTTP_HDR_PROTO)

--- a/bin/varnishd/http1/cache_http1.h
+++ b/bin/varnishd/http1/cache_http1.h
@@ -55,7 +55,7 @@ void V1P_Charge(struct req *, const struct v1p_acct *, struct VSC_vbe *);
 
 /* cache_http1_line.c */
 void V1L_Chunked(const struct worker *w);
-void V1L_EndChunk(const struct worker *w);
+void V1L_EndChunk(const struct worker *w, const struct http *hp);
 void V1L_Open(struct worker *, struct ws *, int *fd, struct vsl_log *,
     double t0, unsigned niov);
 unsigned V1L_Flush(const struct worker *w);

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -144,10 +144,10 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 		return;
 	}
 
-	req->acct.resp_hdrbytes += HTTP1_Write(req->wrk, req->resp, HTTP1_Resp);
-
 	if (tr)
-		HTTP1_MarkTrailer(req->resp);
+		HTTP1_PrepTrailer(req->resp);
+
+	req->acct.resp_hdrbytes += HTTP1_Write(req->wrk, req->resp, HTTP1_Resp);
 
 	if (DO_DEBUG(DBG_FLUSH_HEAD))
 		(void)V1L_Flush(req->wrk);

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -176,7 +176,7 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 		V1L_Chunked(req->wrk);
 	err = VDP_DeliverObj(req);
 	if (!err && (req->res_mode & RES_CHUNKED))
-		V1L_EndChunk(req->wrk);
+		V1L_EndChunk(req->wrk, req->resp);
 
 	if ((V1L_Close(req->wrk) || err) && req->sp->fd >= 0)
 		Req_Fail(req, SC_REM_CLOSE);

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -96,7 +96,11 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 		tr = req->http->protover == 11 &&
 			http_GetHdr(req->resp, H_Trailer, NULL);
 
-		if (!tr && http_GetHdr(req->resp, H_Content_Length, NULL))
+		if (tr) {
+			http_Unset(req->resp, H_Content_Length);
+			req->res_mode |= RES_CHUNKED;
+			http_SetHeader(req->resp, "Transfer-Encoding: chunked");
+		} else if (http_GetHdr(req->resp, H_Content_Length, NULL))
 			req->res_mode |= RES_LEN;
 		else if (req->http->protover == 11) {
 			req->res_mode |= RES_CHUNKED;

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -132,7 +132,7 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 		return;
 	}
 
-	if (req->resp_len == 0)
+	if (req->resp_len == 0 && tr == 0)
 		sendbody = 0;
 
 	if (sendbody)

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -86,14 +86,17 @@ v1d_error(struct req *req, const char *msg)
 void __match_proto__(vtr_deliver_f)
 V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 {
-	int err;
+	int err = 0, tr = 0;
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	CHECK_OBJ_ORNULL(boc, BOC_MAGIC);
 	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
 
 	if (sendbody) {
-		if (http_GetHdr(req->resp, H_Content_Length, NULL))
+		tr = req->http->protover == 11 &&
+			http_GetHdr(req->resp, H_Trailer, NULL);
+
+		if (!tr && http_GetHdr(req->resp, H_Content_Length, NULL))
 			req->res_mode |= RES_LEN;
 		else if (req->http->protover == 11) {
 			req->res_mode |= RES_CHUNKED;
@@ -101,6 +104,7 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 		} else {
 			req->res_mode |= RES_EOF;
 			req->doclose = SC_TX_EOF;
+			tr = 0;
 		}
 	}
 
@@ -141,6 +145,9 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 	}
 
 	req->acct.resp_hdrbytes += HTTP1_Write(req->wrk, req->resp, HTTP1_Resp);
+
+	if (tr)
+		HTTP1_MarkTrailer(req->resp);
 
 	if (DO_DEBUG(DBG_FLUSH_HEAD))
 		(void)V1L_Flush(req->wrk);

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -119,7 +119,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr,
 			bo->req->doclose = SC_RX_BODY;
 		}
 		if (do_chunked)
-			V1L_EndChunk(wrk);
+			V1L_EndChunk(wrk, bo->req->http);
 	}
 
 	j = V1L_Close(wrk);

--- a/bin/varnishd/http1/cache_http1_line.c
+++ b/bin/varnishd/http1/cache_http1_line.c
@@ -300,13 +300,14 @@ V1L_Chunked(const struct worker *wrk)
  */
 
 void
-V1L_EndChunk(const struct worker *wrk)
+V1L_EndChunk(const struct worker *wrk, const struct http *hp)
 {
 	struct v1l *v1l;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	v1l = wrk->v1l;
 	CHECK_OBJ_NOTNULL(v1l, V1L_MAGIC);
+	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
 
 	assert(v1l->ciov < v1l->siov);
 	(void)V1L_Flush(wrk);
@@ -314,5 +315,5 @@ V1L_EndChunk(const struct worker *wrk)
 	v1l->ciov = v1l->siov;
 	v1l->niov = 0;
 	v1l->cliov = 0;
-	(void)V1L_Write(wrk, "0\r\n\r\n", -1);
+	(void)HTTP1_WriteChunkedTrailer(wrk, hp);
 }

--- a/bin/varnishd/http1/cache_http1_proto.c
+++ b/bin/varnishd/http1/cache_http1_proto.c
@@ -509,3 +509,19 @@ HTTP1_Write(const struct worker *w, const struct http *hp, const int *hf)
 	l += V1L_Write(w, "\r\n", -1);
 	return (l);
 }
+
+unsigned
+HTTP1_WriteChunkedTrailer(const struct worker *w, const struct http *hp)
+{
+	unsigned u, l;
+
+	if (hp->thd == 0 || hp->thd == hp->nhd)
+		return (V1L_Write(w, "0\r\n\r\n", 5));
+
+	assert(hp->thd < hp->nhd);
+	l = V1L_Write(w, "0\r\n", 3);
+	for (u = hp->thd; u < hp->nhd; u++)
+		l += http1_WrTxt(w, &hp->hd[u], "\r\n");
+	l += V1L_Write(w, "\r\n", 2);
+	return (l);
+}

--- a/bin/varnishd/http1/cache_http1_proto.c
+++ b/bin/varnishd/http1/cache_http1_proto.c
@@ -124,14 +124,14 @@ HTTP1_DissectHdrs(struct http *hp, char **pp, const char *e,
 
 		/* Find end of next header */
 		q = r = p;
-		if (vct_iscrlf(p))
+		if (vct_iscrlforlf(p))
 			break;
 		while (r < e) {
 			if (!vct_isctl(*r) || vct_issp(*r)) {
 				r++;
 				continue;
 			}
-			if (!vct_iscrlf(r)) {
+			if (!vct_iscrlforlf(r)) {
 				VSLb(hp->vsl, SLT_BogoHeader,
 				    "Header has ctrl char 0x%02x", *r);
 				return (400);
@@ -141,7 +141,7 @@ HTTP1_DissectHdrs(struct http *hp, char **pp, const char *e,
 			r += vct_skipcrlf(r);
 			if (r >= e)
 				break;
-			if (vct_iscrlf(r))
+			if (vct_iscrlforlf(r))
 				break;
 			/* If line does not continue: got it. */
 			if (!vct_issp(*r))
@@ -272,7 +272,7 @@ http1_splitline(struct http *hp, struct http_conn *htc, const int *hf,
 	hp->hd[hf[2]].b = p;
 
 	/* Third field is optional and cannot contain CTL except TAB */
-	for (; !vct_iscrlf(p); p++) {
+	for (; !vct_iscrlforlf(p); p++) {
 		if (vct_isctl(*p) && !vct_issp(*p)) {
 			hp->hd[hf[2]].b = NULL;
 			return (400);

--- a/bin/varnishd/http1/cache_http1_proto.c
+++ b/bin/varnishd/http1/cache_http1_proto.c
@@ -481,8 +481,6 @@ http1_WrTxt(const struct worker *wrk, const txt *hh,
 {
 	unsigned u;
 
-	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
-	AN(wrk);
 	AN(hh);
 	AN(hh->b);
 	AN(hh->e);
@@ -497,10 +495,8 @@ HTTP1_Write(const struct worker *w, const struct http *hp, const int *hf)
 {
 	unsigned u, l;
 
+	CHECK_OBJ_NOTNULL(w, WORKER_MAGIC);
 	assert(hf == HTTP1_Req || hf == HTTP1_Resp);
-	AN(hp->hd[hf[0]].b);
-	AN(hp->hd[hf[1]].b);
-	AN(hp->hd[hf[2]].b);
 	l = http1_WrTxt(w, &hp->hd[hf[0]], " ", 1);
 	l += http1_WrTxt(w, &hp->hd[hf[1]], " ", 1);
 	l += http1_WrTxt(w, &hp->hd[hf[2]], "\r\n", 2);

--- a/bin/varnishd/http1/cache_http1_proto.c
+++ b/bin/varnishd/http1/cache_http1_proto.c
@@ -507,6 +507,18 @@ HTTP1_Write(const struct worker *w, const struct http *hp, const int *hf)
 	return (l);
 }
 
+/*
+ * setting thd is a signal that headers can be added and the staring point
+ * for HTTP1_WriteChunkedTrailer
+ */
+void
+HTTP1_MarkTrailer(struct http *hp)
+{
+	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
+	AZ(hp->thd);
+	hp->thd = hp->nhd;
+}
+
 unsigned
 HTTP1_WriteChunkedTrailer(const struct worker *w, const struct http *hp)
 {

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -113,23 +113,6 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 }
 
 /*--------------------------------------------------------------------
- * check if header is in Trailer
- * XXX could be more efficient by avoiding repeated GetHdr in GetHdrToken
- */
-static int
-v1f_trailer_part_allowed(const struct http *hp, const char *hdr)
-{
-	const char *p = strchr(hdr, ':');
-	const int l = (int)pdiff(hdr, p);
-	char cp[l + 1];
-
-	(void)strncpy(cp, hdr, l);
-	cp[l] = '\0';
-
-	return (http_GetHdrToken(hp, H_Trailer, cp, NULL, NULL));
-}
-
-/*--------------------------------------------------------------------
  * log and filter trailer parts based on Trailer header
  *
  * Ref: https://tools.ietf.org/html/rfc7230#section-4.4
@@ -148,7 +131,7 @@ v1f_trailer_part_process(struct http *hp, int filter)
 	for (v = u = hp->thd; u < hp->nhd; u++) {
 		Tcheck(hp->hd[u]);
 
-		if (filter && ! v1f_trailer_part_allowed(hp, hp->hd[u].b)) {
+		if (filter && ! HTTP1_InTrailer(hp, hp->hd[u].b)) {
 			http_VSLH_del(hp, u);
 			continue;
 		}

--- a/bin/varnishtest/tests/e00031.vtc
+++ b/bin/varnishtest/tests/e00031.vtc
@@ -1,0 +1,123 @@
+varnishtest "ESI include with reqtop trailer"
+
+# taken from e00003.vtc
+
+server s1 {
+	rxreq
+	txresp -body {
+		<html>
+		Before include
+		<esi:include src="/body" sr="foo"/>
+		After include
+		</html>
+	}
+	rxreq
+	expect req.url == "/body1"
+	txresp -body {
+		Included file
+	}
+	rxreq
+	txresp -body {
+		<html>
+		Before include
+		<esi:include src="/body" sr="foo"/>
+		After include
+		</html>
+	}
+	rxreq
+	expect req.url == "/body1"
+	txresp -body {
+		Included file
+	}
+} -start
+
+varnish v1 -vcl+backend {
+	import debug;
+	sub vcl_recv {
+		if (req.esi_level > 0) {
+			set req.url = req.url + req.esi_level;
+		}
+		if (req.http.TE != "trailers") {
+		   unset req.http.TE;
+		}
+	}
+	sub vcl_backend_response {
+		set beresp.do_esi = true;
+		set beresp.http.Vary = "TE";
+	}
+	sub vcl_deliver {
+		if (req.http.TE) {
+		    if (req.esi_level == 0) {
+			set resp.http.Trailer = "FromESI";
+		    } else {
+			debug.topresp_trailer("FromESI: " + req.esi_level);
+		    }
+		}
+		unset resp.http.Vary;
+	}
+} -start
+
+logexpect l1 -v v1 -g request {
+	expect 0 1001   Begin   "^req .* rxreq"
+	expect * =	ReqAcct	"^18 0 18 187 75 262$"
+	expect 0 =      End
+} -start
+
+logexpect l2 -v v1 -g request {
+	expect * 1002   Begin   "^bereq "
+	expect * =      End
+} -start
+
+logexpect l3 -v v1 -g request {
+	expect * 1003   Begin   "^req .* esi"
+	expect * =	ReqAcct	"^0 0 0 0 18 18$"
+	expect 0 =      End
+} -start
+
+logexpect l4 -v v1 -g request {
+	expect * 1004   Begin   "^bereq "
+	expect * =      End
+} -start
+
+logexpect l5 -v v1 -g request {
+	expect * 1005   Begin   "^req .* rxreq"
+	expect * =	ReqAcct	"^18 0 18 192 75 267$"
+	expect 0 =      End
+} -start
+
+client c1 {
+	# original behaviour - no TE
+
+	txreq
+	rxresp
+	expect resp.bodylen == 75
+	expect resp.status == 200
+	expect resp.http.Trailer == <undef>
+	expect resp.http.FromESI == <undef>
+
+	delay .1
+	# test that there is no difference on miss/hit
+	txreq
+	rxresp
+	expect resp.bodylen == 75
+	expect resp.status == 200
+	expect resp.http.Trailer == <undef>
+	expect resp.http.FromESI == <undef>
+
+	# trailers
+	txreq -hdr "TE: trailers"
+	rxresp
+	expect resp.bodylen == 75
+	expect resp.status == 200
+	expect resp.http.Trailer == FromESI
+	expect resp.http.FromESI == 1
+}
+
+client c1 -run
+varnish v1 -expect esi_errors == 0
+
+logexpect l1 -wait
+logexpect l2 -wait
+logexpect l3 -wait
+logexpect l4 -wait
+logexpect l5 -wait

--- a/bin/varnishtest/tests/e00032.vtc
+++ b/bin/varnishtest/tests/e00032.vtc
@@ -80,6 +80,7 @@ varnish v1 -vcl+backend {
 	    if (req.esi_level > 0) {
 		call deliver_esi;
 	    }
+	    set resp.http.X-ESI = req.url;
 	    if (req.http.TE == "trailers") {
 		set resp.http.Trailer = "X-ESI";
 	    }
@@ -115,14 +116,14 @@ client c1 {
 	expect resp.status == 200
 	expect resp.bodylen == 81
 	expect resp.http.Trailer == "X-ESI"
-	expect resp.http.X-ESI == "/a1:/c2:/b1"
+	expect resp.http.X-ESI == "/:/a1:/c2:/b1"
 	expect resp.http.hits == "0"
 
 	# this fails at esi level 1 - body contains "503 VCL failed"
 	txreq
 	rxresp
 	expect resp.status == 200
-	expect resp.http.X-ESI == <undef>
+	expect resp.http.X-ESI == "/"
 	expect resp.bodylen == 562
 
 	txreq -hdr "TE: trailers"
@@ -130,7 +131,7 @@ client c1 {
 	expect resp.status == 200
 	expect resp.bodylen == 81
 	expect resp.http.Trailer == "X-ESI"
-	expect resp.http.X-ESI == "/a1:/c2:/b1"
+	expect resp.http.X-ESI == "/:/a1:/c2:/b1"
 	expect resp.http.hits == "2"
 } -run
 

--- a/bin/varnishtest/tests/e00032.vtc
+++ b/bin/varnishtest/tests/e00032.vtc
@@ -27,6 +27,16 @@ server s1 {
 	rxreq
 	expect req.url == "/b1"
 	txresp
+
+	# -
+
+	rxreq
+	expect req.url == "/nobody"
+	txresp -body {<esi:include src="/nobodyinc"/>}
+
+	rxreq
+	expect req.url == "/nobodyinc1"
+	txresp -body {}
 } -start
 
 varnish v1 -arg "-p feature=+esi_disable_xml_check" -vcl+backend {} -start
@@ -133,6 +143,14 @@ client c1 {
 	expect resp.http.Trailer == "X-ESI"
 	expect resp.http.X-ESI == "/:/a1:/c2:/b1"
 	expect resp.http.hits == "2"
+
+	txreq -url /nobody -hdr "TE: trailers"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 0
+	expect resp.http.Trailer == "X-ESI"
+	expect resp.http.X-ESI == "/nobody:/nobodyinc1"
+	expect resp.http.hits == "0"
 } -run
 
 varnish v1 -expect esi_errors == 0

--- a/bin/varnishtest/tests/e00032.vtc
+++ b/bin/varnishtest/tests/e00032.vtc
@@ -1,0 +1,138 @@
+varnishtest "Test resp_top.* in an ESI context"
+
+# based on e30.vtc (req_top)
+
+server s1 {
+	rxreq
+	txresp -body {
+		<html>
+		Before include
+		<esi:include src="/a"/>
+		<esi:include src="/b"/>
+		After include
+		</html>
+	}
+
+	rxreq
+	expect req.url == "/a1"
+	txresp -body {
+		Included file
+		<esi:include src="/c"/>
+	}
+
+	rxreq
+	expect req.url == "/c2"
+	txresp
+
+	rxreq
+	expect req.url == "/b1"
+	txresp
+} -start
+
+varnish v1 -arg "-p feature=+esi_disable_xml_check" -vcl+backend {} -start
+
+varnish v1 -errvcl {Variable 'resp_top.proto' is read only.} {
+	sub vcl_deliver {
+		set resp_top.proto = "foo";
+	}
+}
+
+varnish v1 -errvcl {Variable 'resp_top.status' is read only.} {
+	sub vcl_deliver {
+		set resp_top.status = 500;
+	}
+}
+
+varnish v1 -errvcl {Variable 'resp_top.reason' is read only.} {
+	sub vcl_deliver {
+		set resp_top.reason = "foo";
+	}
+}
+
+varnish v1 -vcl+backend {
+	sub recv_test_runtime_access {
+	    if (req.url == "/level0readrecv") {
+		set req.http.foo = resp_top.http.foo;
+		return (synth(200));
+	    }
+	    if (req.url == "/level0writerecv") {
+		set resp_top.http.foo = req.http.foo;
+		return (synth(200));
+	    }
+	}
+	sub vcl_recv {
+	    if (req.esi_level > 0) {
+		set req.url = req.url + req.esi_level;
+		return (hash);
+	    }
+
+	    call recv_test_runtime_access;
+	}
+	sub deliver_esi {
+	    if (resp_top.http.X-ESI) {
+		set resp_top.http.X-ESI = resp_top.http.X-ESI + ":" + req.url;
+	    } else {
+		set resp_top.http.X-ESI = req.url;
+	    }
+	    return (deliver);
+	}
+	sub vcl_deliver {
+	    if (req.esi_level > 0) {
+		call deliver_esi;
+	    }
+	    if (req.http.TE == "trailers") {
+		set resp.http.Trailer = "X-ESI";
+	    }
+	    unset resp.http.Vary;
+	    set resp.http.hits = obj.hits;
+	}
+	sub vcl_backend_response {
+	    set beresp.do_esi = true;
+	}
+}
+
+logexpect l1 -v v1 -g raw {
+	expect * * VCL_Error {^resp_top.http.foo not accessible at esi level 0 outside vcl_deliver/vcl_synth$}
+	expect * * VCL_Error {^resp_top.http.foo not writable at esi level 0 outside vcl_deliver/vcl_synth$}
+#	expect * * VCL_Error {^resp_top.http.X-ESI not writable unless sending Trailers$}
+} -start
+
+client c1 {
+	txreq -url "/level0readrecv"
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
+} -run
+client c1 {
+	txreq -url "/level0writerecv"
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
+} -run
+client c1 {
+	txreq -hdr "TE: trailers"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 81
+	expect resp.http.Trailer == "X-ESI"
+	expect resp.http.X-ESI == "/a1:/c2:/b1"
+	expect resp.http.hits == "0"
+
+	# this fails at esi level 1 - body contains "503 VCL failed"
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.X-ESI == <undef>
+	expect resp.bodylen == 562
+
+	txreq -hdr "TE: trailers"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 81
+	expect resp.http.Trailer == "X-ESI"
+	expect resp.http.X-ESI == "/a1:/c2:/b1"
+	expect resp.http.hits == "2"
+} -run
+
+varnish v1 -expect esi_errors == 0
+logexpect l1 -wait

--- a/bin/varnishtest/tests/r02488.vtc
+++ b/bin/varnishtest/tests/r02488.vtc
@@ -24,7 +24,7 @@ varnish v1 -vcl {
 logexpect l1 -v v1 -g raw {
 	expect * 1002 VCL_call	{^SYNTH$}
 	expect 0    = VCL_Error	{^vmod blob error: cannot encode, out of space$}
-	expect 0    = LostHeader	{^foo:$}
+	expect 0    = LostHeader	{^resp.http.foo$}
 	expect 0    = VCL_return	{^fail$}
 } -start
 

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -557,13 +557,8 @@ http_rxchunk(struct http *hp)
 		return (-1);
 	if (!vct_iscrlf(hp->rxbuf + l)) {
 		vtc_log(hp->vl, hp->fatal,
-		    "Wrong chunk tail[0] = %02x",
-		    hp->rxbuf[l] & 0xff);
-		return (-1);
-	}
-	if (!vct_iscrlf(hp->rxbuf + l + 1)) {
-		vtc_log(hp->vl, hp->fatal,
-		    "Wrong chunk tail[1] = %02x",
+		    "Wrong chunk tail = %02x%02x",
+		    hp->rxbuf[l] & 0xff,
 		    hp->rxbuf[l + 1] & 0xff);
 		return (-1);
 	}

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -389,6 +389,44 @@ cmd_http_expect_pattern(CMD_ARGS)
 }
 
 /**********************************************************************
+ * add headers below those from the request/status line
+ */
+
+static void
+http_addheader(struct http *hp, char **hh, int n, char *p)
+{
+	char buf[20];
+	char *q;
+	int o;
+
+	while (hh[n] != NULL) {
+		n++;
+		assert(n <= MAX_HDR);
+	}
+	assert(n >= 3);
+	o = n;
+
+	while (*p != '\0') {
+		assert(n < MAX_HDR);
+		if (vct_iscrlf(p))
+			break;
+		hh[n++] = p++;
+		while (*p != '\0' && !vct_iscrlf(p))
+			p++;
+		q = p;
+		p += vct_skipcrlf(p);
+		*q = '\0';
+	}
+	p += vct_skipcrlf(p);
+	assert(*p == '\0');
+
+	for (; o < n; o++) {
+		bprintf(buf, "http[%2d] ", o);
+		vtc_dump(hp->vl, 4, buf, hh[o], -1);
+	}
+}
+
+/**********************************************************************
  * Split a HTTP protocol header
  */
 
@@ -446,24 +484,11 @@ http_splitheader(struct http *hp, int req)
 	}
 	assert(n == 3);
 
-	while (*p != '\0') {
-		assert(n < MAX_HDR);
-		if (vct_iscrlf(p))
-			break;
-		hh[n++] = p++;
-		while (*p != '\0' && !vct_iscrlf(p))
-			p++;
-		q = p;
-		p += vct_skipcrlf(p);
-		*q = '\0';
-	}
-	p += vct_skipcrlf(p);
-	assert(*p == '\0');
-
-	for (n = 0; n < 3 || hh[n] != NULL; n++) {
+	for (n = 0; n < 3; n++) {
 		bprintf(buf, "http[%2d] ", n);
 		vtc_dump(hp->vl, 4, buf, hh[n], -1);
 	}
+	return (http_addheader(hp, hh, n, p));
 }
 
 
@@ -524,6 +549,70 @@ http_rxchar(struct http *hp, int n, int eof)
 	return (1);
 }
 
+#define trail_err(hp, q, s) do {					\
+		vtc_log((hp)->vl, (hp)->fatal,				\
+			"Wrong chunk end %s: %02x%02x",		\
+			(s), *(q), *((q) + 1));				\
+		return (-1);						\
+	} while(0)
+
+/*
+ * prxbuf is at line after (length) 0
+ */
+static int
+http_rxchunk_end(struct http *hp)
+{
+	char *h;
+	const char *q, *lim;
+	unsigned u = 0;
+
+	h = hp->rxbuf + hp->prxbuf;
+	q = h;
+
+	if (http_rxchar(hp, 2, 0) < 0)
+		return (-1);
+	lim = q + 2;
+	if (vct_iscrlf(q))
+		return (0);	/* no trailer-parts */
+
+	while (1) {
+		vtc_dump(hp->vl, 4, "trail", q, lim - q);
+		while (q < lim) {
+			switch (*q) {
+			case '\r': {
+				if (u & 1)
+					trail_err(hp, q, "CRCR");
+				u++;
+				break;
+			}
+			case '\n': {
+				if ((u & 1) == 0)
+					trail_err(hp, q, "LF no CR");
+				u++;
+				break;
+			}
+			default:
+				if (u & 1)
+					trail_err(hp, q, "CR no LF");
+				u = 0;
+			}
+			q++;
+		}
+		if (u >= 4)
+			break;
+		if (http_rxchar(hp, 4 - u, 0) < 0)
+			return (-1);
+		q = lim;
+		lim += 4 - u;
+	}
+	assert(u == 4);
+
+	/* trailer */
+	http_addheader(hp, hp->resp, 0, h);
+	return (0);
+}
+#undef trail_err
+
 static int
 http_rxchunk(struct http *hp)
 {
@@ -546,12 +635,21 @@ http_rxchunk(struct http *hp)
 	}
 	assert(q != hp->rxbuf + l);
 	assert(*q == '\0' || vct_islws(*q));
-	hp->prxbuf = l;
-	if (i > 0) {
-		if (http_rxchar(hp, i, 0) < 0)
-			return (-1);
-		vtc_dump(hp->vl, 4, "chunk", hp->rxbuf + l, i);
+
+	if (i == 0) {
+		i = http_rxchunk_end(hp);
+		hp->prxbuf = l;
+		hp->rxbuf[l] = '\0';
+		/* XXX trailers are located behind prxbuf now */
+		return (i);
 	}
+	assert(i > 0);
+
+	hp->prxbuf = l;
+	if (http_rxchar(hp, i, 0) < 0)
+		return (-1);
+	vtc_dump(hp->vl, 4, "chunk", hp->rxbuf + l, i);
+
 	l = hp->prxbuf;
 	if (http_rxchar(hp, 2, 0) < 0)
 		return (-1);

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -36,6 +36,7 @@ nobase_pkginclude_HEADERS = \
 	tbl/vhd_return.h \
 	tbl/vhp_huffman.h \
 	tbl/vhp_static.h \
+	tbl/vrt_hdr_where.h \
 	tbl/vrt_stv_var.h \
 	tbl/vsc_levels.h \
 	tbl/vsl_tags.h \
@@ -104,6 +105,7 @@ vmod_abi.h: $(top_srcdir)/lib/libvcc/generate.py $(top_srcdir)/include/vrt.h
 	@PYTHON@ $(top_srcdir)/lib/libvcc/generate.py $(top_srcdir) $(top_builddir)
 
 GEN_H = \
+	tbl/vrt_hdr_where.h \
 	tbl/vrt_stv_var.h \
 	tbl/vcl_returns.h \
 	tbl/vcc_types.h \

--- a/include/vct.h
+++ b/include/vct.h
@@ -76,7 +76,8 @@ vct_is(int x, uint16_t y)
 #define vct_isxmlname(x) vct_is(x, VCT_XMLNAMESTART | VCT_XMLNAME)
 #define vct_istchar(x) vct_is(x, VCT_ALPHA | VCT_DIGIT | VCT_TCHAR)
 
-#define vct_iscrlf(p) (((p)[0] == 0x0d && (p)[1] == 0x0a) || (p)[0] == 0x0a)
+#define vct_iscrlf(p) ((p)[0] == 0x0d && (p)[1] == 0x0a)
+#define vct_iscrlforlf(p) (vct_iscrlf(p) || (p)[0] == 0x0a)
 
 /* NB: VCT always operate in ASCII, don't replace 0x0d with \r etc. */
 #define vct_skipcrlf(p) ((p)[0] == 0x0d && (p)[1] == 0x0a ? 2 : 1)

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -159,6 +159,7 @@ struct vrt_ctx {
 	struct http			*http_req;
 	struct http			*http_req_top;
 	struct http			*http_resp;
+	struct http			*http_resp_top;
 
 	struct busyobj			*bo;
 	struct http			*http_bereq;
@@ -326,6 +327,7 @@ enum gethdr_e {
 	HDR_REQ,
 	HDR_REQ_TOP,
 	HDR_RESP,
+	HDR_RESP_TOP,
 	HDR_OBJ,
 	HDR_BEREQ,
 	HDR_BERESP
@@ -336,7 +338,13 @@ struct gethdr_s {
 	const char	*what;
 };
 
-struct http *VRT_selecthttp(VRT_CTX, enum gethdr_e);
+const char *VRT_hdr_where(const enum gethdr_e);
+void VRT_hdr_fail(VRT_CTX, const struct gethdr_s * const,
+    const char *err, const char *why);
+struct http *VRT_http_ref_rw(VRT_CTX, enum gethdr_e, const char **why);
+void VRT_http_deref_rw(struct http **);
+const struct http *VRT_http_ref_ro(VRT_CTX, enum gethdr_e, const char **why);
+void VRT_http_deref_ro(const struct http **);
 const char *VRT_GetHdr(VRT_CTX, const struct gethdr_s *);
 
 /***********************************************************************

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -221,3 +221,5 @@ Add a vsc
 $Function VOID vsc_destroy()
 
 Remove a vsc
+
+$Function VOID topresp_trailer(STRING)

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -194,10 +194,16 @@ VCL_VOID __match_proto__(td_std_collect)
 vmod_collect(VRT_CTX, VCL_HEADER hdr, VCL_STRING sep)
 {
 	struct http *hp;
+	const char *why;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	hp = VRT_selecthttp(ctx, hdr->where);
+	hp = VRT_http_ref_rw(ctx, hdr->where, &why);
+	if (hp == NULL) {
+		VRT_hdr_fail(ctx, hdr, "not writable", why);
+		return;
+	}
 	http_CollectHdrSep(hp, hdr->what, sep);
+	VRT_http_deref_rw(&hp);
 }
 
 VCL_BOOL __match_proto__(td_std_healthy)


### PR DESCRIPTION
Continuing and based upon #5

Please read the individual commit messages. Overall, the changes are:
* varnishtest support for chunk trailers
* writing trailers downstream with chunked encoding
* basic support in cache_http

commits most relevant regarding interfaces:
* 3bd54778313d8af6e134ac1645d16f746772ec98 is a minimalistic "mvp" interface included here only as a reference point for reviewers
* 3d083e1184cbfdd5ea290cc1d31dbfb64d6d3326 is a suggestion for full-blown VRT support to access trailers from esi_level > 0 as `resp_top.http.*`
The latter requires introduction of run time header access control to VRT which is suggested as a reference/dereference pattern replacing `VRT_selecthttp()`